### PR TITLE
docs(meta): sync CLAUDE.md, README, version metadata with v0.6.0 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,25 +2,28 @@
 
 ## Project Overview
 
-Generate and audit CLAUDE.md files for AI coding agents. Freemium CLI with Pro license server and Stripe-automated fulfillment.
+Generate and audit AI-agent context files (CLAUDE.md, AGENTS.md) for AI coding agents. Freemium CLI + web UI with a Stripe-automated license server. Three paid tiers: Pro (individual), Strict (CI / procurement), and one-off web scans.
 
-Commands: `generate`, `audit` (structure scoring), `verify` (reality check — claims vs filesystem), `fleet` (cross-repo audit), `harvest` (recurring gotchas from Claude Code transcripts), `patch` (splice harvested anti-patterns into existing CLAUDE.md), plus Pro: `init`, `diff`, `tech-debt`, `github-health`, `cleanup`, `drift`.
+Commands: `generate`, `audit` (structure scoring), `verify` (reality check — claims vs filesystem), `fleet` (cross-repo audit), `harvest` (recurring gotchas from Claude Code transcripts), `patch` (splice harvested anti-patterns into existing CLAUDE.md), plus Pro: `init`, `diff`, `tech-debt`, `github-health`, `cleanup`, `drift`. Strict adds fail-closed validation, team seats, and a server-side audit log.
 
 ## Current State
 
-- **Version**: 0.5.0
-- **Language**: Python
-- **Tests**: 134 (license server) + ~390 client-side tests (including verify/fleet/harvest/patch/suggestions)
-- **License Server**: `https://cmdf-license.fly.dev` (Fly.io, SQLite + WAL)
-- **Stripe**: Live — automated checkout → key generation → email delivery
+- **Version**: 0.6.0 (shipped 2026-05-17; see CHANGELOG.md)
+- **Language**: Python 3.11+
+- **Tests**: 811 passing (client + license server combined)
+- **License Server**: `https://cmdf-license.fly.dev` (Fly.io, SQLite + WAL, Litestream HA via `license_server/litestream.yml`)
+- **Web UI**: `anchormd-web` on Fly.io (deployed from project root via `fly.web.toml`)
+- **Stripe**: Live — automated checkout → key generation → email delivery for Pro and Strict SKUs
 
 ## Monetization
 
-- **Free**: `generate`, `audit`, 11 community presets
-- **Pro ($8/mo or $69/yr)**: `init`, `diff`, CI integration, 6 premium presets, team templates
-- **Template Packs**: Gumroad ($5-10 each)
+- **Free**: `generate`, `audit`, 11 community presets, AGENTS.md/Codex/CLAUDE.md exports, `drift run` / `drift report` (terminal)
+- **Pro ($8/mo or $69/yr)**: `init`, `diff`, 6 premium presets, team templates, `tech-debt`, `github-health`, `cleanup`
+- **Strict ($49/seat/mo · $399/yr team-5 · $1,490/yr team-25)**: Fail-closed license validation (`ANCHORMD_STRICT=1`), team seats, 365-day audit log, fleet `--json` + history, CI integration (PR-comment automation), advanced drift (`drift generate`, `drift fix`, `drift report --ci/--html`, `--judge-model`)
+- **Template Packs**: Gumroad ($5–10 each)
+- **One-time web scan**: $29 deep scan (planned)
 - **Payment Links**: Stripe Payment Links → webhook → auto key + email
-- **Do NOT modify pricing without explicit approval**
+- **Do NOT modify pricing tiers without explicit approval** (the Pro→Strict feature moves in v0.6.0 were approved; future moves are not)
 
 ## Architecture
 
@@ -28,59 +31,75 @@ Commands: `generate`, `audit` (structure scoring), `verify` (reality check — c
 anchormd/
 ├── .github/workflows/
 ├── docs/
-├── license_server/           # FastAPI license server (separate deployable)
-│   ├── migrations/           # SQLite schema migrations
+│   ├── strict.md                 # Strict tier docs
+│   └── STRICT_SPEC.md            # Internal spec
+├── license_server/               # FastAPI license server (separate deployable)
+│   ├── migrations/               # 001..006 (latest: seats, audit_events)
 │   ├── routes/
-│   │   ├── activate.py       # POST /v1/activate (admin)
-│   │   ├── validate.py       # POST /v1/validate
-│   │   ├── revoke.py         # POST /v1/revoke (admin)
-│   │   └── webhook.py        # POST /v1/webhooks/stripe
-│   ├── stripe_webhooks.py    # Event handlers (checkout, cancel, payment_failed)
-│   ├── email_delivery.py     # SMTP license key delivery
-│   ├── key_gen.py            # ANMD-XXXX-XXXX-XXXX generation + hashing
-│   ├── config.py             # Env var configuration
-│   ├── database.py           # SQLite connection + migration runner
-│   ├── models.py             # Pydantic request/response models
-│   ├── rate_limit.py         # slowapi rate limiter
-│   ├── Dockerfile            # Multi-stage build for Fly.io
-│   ├── fly.toml              # Fly.io deployment config
-│   └── requirements.txt      # Server dependencies
-├── output/
-├── packs/                    # Gumroad template packs
+│   │   ├── activate.py           # POST /v1/activate (admin)
+│   │   ├── validate.py           # POST /v1/validate
+│   │   ├── revoke.py             # POST /v1/revoke (admin)
+│   │   ├── usage.py              # POST /v1/usage{,/check}
+│   │   ├── seats.py              # POST /v1/seats/{claim,release}, GET /v1/seats/list
+│   │   ├── audit.py              # POST /v1/audit/log, GET /v1/audit/export
+│   │   └── webhook.py            # POST /v1/webhooks/stripe
+│   ├── stripe_webhooks.py        # Event handlers (Pro + Strict checkout, cancel, payment_failed)
+│   ├── email_delivery.py         # SMTP delivery (welcome + Strict welcome with CI snippet)
+│   ├── key_gen.py                # ANMD-XXXX-XXXX-XXXX generation + hashing
+│   ├── config.py                 # Env var configuration
+│   ├── database.py               # SQLite + migration runner
+│   ├── models.py                 # Pydantic request/response models
+│   ├── rate_limit.py             # slowapi rate limiter
+│   ├── litestream.yml            # Litestream HA replication config
+│   ├── scripts/restore.sh        # Restore-on-start wrapper
+│   ├── Dockerfile, fly.toml, requirements.txt
+│   └── pyproject.toml            # Server package metadata (kept in sync with root)
+├── packs/                        # Gumroad template packs
 ├── prompts/
 ├── scripts/
-│   ├── stripe_setup.py       # Create Stripe products/prices/payment links
-│   └── keygen.py             # Manual key generation (legacy)
-├── src/anchormd/       # CLI package (PyPI: anchormd)
-│   ├── licensing.py          # Client-side key detection, validation, caching
-│   ├── machine_id.py         # Hostname+username hash
-│   ├── gates.py              # @require_pro feature gating
-│   └── cli.py                # Typer CLI
-├── tests/
-│   ├── drift/
-│   └── license_server/
-├── web/                         # Phase 1 Web UI (anchormd-web on Fly.io)
-│   ├── app.py                   # FastAPI: POST /api/scan, GET /api/scan/{id}
-│   ├── generator.py             # Wrapper around anchormd generation logic
-│   ├── frontend/                # React + Vite + Tailwind (dark theme)
-│   └── Dockerfile               # Multi-stage build (Node + Python)
-├── fly.web.toml                 # Fly.io config for anchormd-web (deploy from project root)
-├── .dockerignore
-├── pyproject.toml
+│   ├── stripe_setup.py           # Create Stripe products/prices/payment links (supports --strict-only)
+│   └── keygen.py                 # Manual key generation (legacy)
+├── src/anchormd/                 # CLI package (PyPI: anchormd)
+│   ├── cli.py                    # Typer CLI entrypoint
+│   ├── licensing.py              # Key detection, validation, caching, Tier enum
+│   ├── gates.py                  # @require_pro, @require_strict decorators
+│   ├── seats.py                  # Client-side seat claim (Strict)
+│   ├── audit_logger.py           # Fire-and-forget audit POST (Strict)
+│   ├── telemetry.py              # Anonymous gate-event tracking
+│   ├── machine_id.py             # Hostname+username hash
+│   ├── scanner.py                # Repo introspection
+│   ├── config.py, models.py, exceptions.py
+│   ├── ci.py, cleanup.py
+│   ├── analyzers/                # commands, domain, github, harvest, language,
+│   │                             # opsec, patterns, reality, skills, suggestions, tech_debt
+│   ├── generators/               # auditor, composer, patcher, sections, checkers/
+│   ├── drift/                    # cli, generator, fixer, runner, scorer, reporter,
+│   │                             # storage, trend, adapters/, templates/
+│   └── templates/                # base, frameworks, presets
+├── web/                          # Web UI (anchormd-web on Fly.io)
+│   ├── app.py                    # FastAPI: POST /api/scan, GET /api/scan/{id}
+│   ├── generator.py              # Wrapper around anchormd generation logic
+│   ├── frontend/                 # React + Vite + Tailwind (dark theme; StrictPage, PricingPage)
+│   └── Dockerfile                # Multi-stage build (Node + Python)
+├── tests/                        # 811 tests; mirrors src/ + tests/license_server/
+├── substack-drafts/              # Launch copy
+├── skills/                       # Claude Code skill definitions
+├── fly.web.toml, vercel.json, action.yml
+└── pyproject.toml
 ```
 
 ## Tech Stack
 
-- **Language**: Python, HTML, SQL
+- **Language**: Python, HTML, SQL, JavaScript (web frontend)
 - **Package Manager**: pip
-- **Linters**: ruff
-- **Formatters**: ruff
-- **Type Checkers**: mypy
+- **Linters / Formatters**: ruff
+- **Type Checkers**: mypy (strict)
 - **Test Frameworks**: pytest
 - **CI/CD**: GitHub Actions
-- **Hosting**: Fly.io (license server), PyPI (CLI)
+- **Hosting**: Fly.io (license server + web UI), PyPI (CLI)
 - **Payments**: Stripe (webhooks + payment links)
 - **Email**: SMTP (Gmail app password)
+- **HA**: Litestream → S3-compatible storage for SQLite replication
 
 ## API Endpoints (License Server)
 
@@ -88,11 +107,16 @@ anchormd/
 |----------|------|------------|---------|
 | `GET /v1/health` | None | 120/min | Health check + license counts |
 | `POST /v1/activate` | Admin Bearer | 10/min | Create license key |
-| `POST /v1/validate` | None | 60/min | Validate license key |
+| `POST /v1/validate` | None | 60/min | Validate license key (returns tier, seats_used/total) |
 | `POST /v1/revoke` | Admin Bearer | 10/min | Revoke license key |
 | `POST /v1/usage/check` | None | 60/min | Check scan quota remaining |
 | `POST /v1/usage` | None | 30/min | Record a scan + return updated quota |
-| `POST /v1/webhooks/stripe` | Stripe signature | 30/min | Automated fulfillment |
+| `POST /v1/seats/claim` | None | 60/min | Strict: claim a seat for this machine |
+| `POST /v1/seats/release` | None | 30/min | Strict: release a seat |
+| `GET /v1/seats/list` | Admin Bearer | 30/min | Strict: list seats for a license |
+| `POST /v1/audit/log` | None | 120/min | Strict: append a CLI invocation event |
+| `GET /v1/audit/export` | Admin Bearer | 10/min | Strict: export audit events (CSV default, JSON optional) |
+| `POST /v1/webhooks/stripe` | Stripe signature | 30/min | Automated fulfillment (Pro + Strict checkout) |
 
 ## License Key System
 
@@ -101,22 +125,29 @@ anchormd/
 - **Storage**: SHA-256 hash only — plaintext never stored
 - **Masking**: `ANMD-****-****-{last4}` for display
 - **Client detection**: `ANCHORMD_LICENSE` env var → `.anchormd-license` → `~/.config/anchormd/license`
-- **Validation**: Local checksum → server call (5s timeout) → 24h cache → fail-open to local-only
+- **Pro validation**: Local checksum → server call (5s timeout) → 24h cache → **fail-open** to local-only
+- **Strict validation** (`ANCHORMD_STRICT=1`): same path, but any validation failure (server unreachable, revoked, expired, no cache) → **fail-closed** non-zero exit
+- **Seats** (Strict): first successful validation per machine triggers `claim_seat_on_startup()`; cap enforced server-side (HTTP 409 over `seats_total`); 24h on-disk claim cache
 
 ## Environment Variables
 
 ### License Server (Fly.io secrets)
 - `ANMD_ADMIN_SECRET` — Bearer token for admin endpoints
 - `ANMD_DB_PATH` — SQLite path (default: `/data/license_server.db`)
+- `ANMD_RATE_LIMIT` — Optional rate-limit override
 - `STRIPE_SECRET_KEY` — Stripe API key
 - `STRIPE_WEBHOOK_SECRET` — Stripe webhook signing secret
-- `ANMD_SMTP_USER` — Gmail address
-- `ANMD_SMTP_PASSWORD` — Gmail app password
+- `ANMD_SMTP_USER` / `ANMD_SMTP_PASSWORD` — Gmail credentials
 - `ANMD_SMTP_FROM` — From address for emails
+- `ANMD_SMTP_HOST` / `ANMD_SMTP_PORT` — SMTP server (defaults: Gmail)
 
 ### Client (user-side)
 - `ANCHORMD_LICENSE` — License key
-- `ANCHORMD_LICENSE_SERVER` — Server URL (optional)
+- `ANCHORMD_LICENSE_SERVER` — Server URL (optional override)
+- `ANCHORMD_STRICT` — Set to `1` to opt into fail-closed validation (Strict tier)
+- `ANCHORMD_NO_AUDIT` — Set to `1` to opt out of Strict audit logging
+- `ANCHORMD_TELEMETRY` — Set to `0` to disable anonymous gate-event tracking
+- `ANCHORMD_DIR` — Override config dir (default: `~/.config/anchormd`)
 
 ## Common Commands
 
@@ -126,13 +157,15 @@ anchormd/
 # test (license server only)
 .venv/bin/python -m pytest tests/license_server/ -v
 # lint
-ruff check src/ tests/ license_server/
+ruff check src/ tests/ license_server/ web/
 # format
-ruff format src/ tests/ license_server/
+ruff format src/ tests/ license_server/ web/
 # type check
 mypy src/
 # deploy license server
 fly deploy --dockerfile license_server/Dockerfile --config license_server/fly.toml
+# deploy web UI
+fly deploy --config fly.web.toml
 # health check
 curl https://cmdf-license.fly.dev/v1/health
 ```
@@ -141,7 +174,7 @@ curl https://cmdf-license.fly.dev/v1/health
 
 - **Naming**: snake_case
 - **Quote Style**: double quotes
-- **Type Hints**: present
+- **Type Hints**: present (mypy strict)
 - **Imports**: absolute
 - **Path Handling**: pathlib
 - **Line Length**: 100 characters
@@ -154,67 +187,58 @@ curl https://cmdf-license.fly.dev/v1/health
 - Do NOT use `os.path` — use `pathlib.Path` everywhere
 - Do NOT use bare `except:` — catch specific exceptions
 - Do NOT use mutable default arguments
-- Do NOT use `print()` for logging — use the `logging` module
+- Do NOT use `print()` for diagnostics or server-side logging — use the `logging` module. (User-facing CLI output via `rich.console` / `typer.echo` is fine.)
 - Do NOT store plaintext license keys in the database
 - Do NOT modify pricing tiers without approval
+- Do NOT add a grandfather/legacy code path for a tier move without approval
 
 ## Dependencies
 
 ### CLI (PyPI)
 - typer, rich, pydantic, tomli, pyyaml, jinja2
-- httpx (optional, for server validation)
+- httpx (optional, for server validation — installed via `anchormd[server]`)
 
 ### License Server (Fly.io)
 - fastapi, uvicorn, pydantic, slowapi, stripe
 
+### Web UI (Fly.io)
+- fastapi, uvicorn (backend) · React + Vite + Tailwind (frontend)
+
 ### Dev
-- pytest, mypy, ruff, httpx
+- pytest, mypy, ruff, httpx — plus license-server runtime deps so `tests/license_server/` collects
 
-## Web UI Roadmap (April 2026 Sprint)
+## Web UI Roadmap
 
-**Strategic context:** Claude Code adoption is accelerating. Every user needs a CLAUDE.md. Most write poor ones. anchormd is the tool that fixes that.
+**Strategic context:** Every coding-agent user needs a CLAUDE.md (or AGENTS.md). Most write poor ones. anchormd is the tool that fixes that. The web UI is the top of funnel; the CLI is the power-user surface; Strict is the procurement-friendly tier.
 
-**Revenue targets:**
-- Free tier: Single repo scan, basic CLAUDE.md output
-- Pro ($8/mo or $69/yr): Full audit, multi-repo, PR integration, history (existing)
-- One-time ($29): Single deep repo scan with recommendations (new web product)
+### Shipped (April–May 2026)
 
-### Phase 1 — MVP Web UI (April 1–14)
-Goal: GitHub URL in → CLAUDE.md out. No auth, no payment. Shareable link.
-- FastAPI endpoint: `POST /scan` — accepts GitHub repo URL, returns generated CLAUDE.md
-- Port generation logic from CLI to `web/generator.py`
-- React landing page: URL input → loading → output with copy button
-- Deploy on Fly.io
+- ✅ Phase 1 — Web MVP: GitHub URL → CLAUDE.md (FastAPI `/api/scan`, React landing, Fly.io)
+- ✅ Phase 2 — Free-tier quota + scan-usage tracking (`/v1/usage`); category breakdown surfaced on free tier
+- ✅ Litestream HA on the license server (restore-on-start)
+- ✅ AGENTS.md / Codex / CLAUDE.md exports + agent-neutral copy
+- ✅ Strict tier (v0.6.0, 2026-05-17): fail-closed validation, seats, audit log, three Strict SKUs
 
-**Done when:** A stranger can paste a public GitHub URL and get a usable CLAUDE.md in under 30 seconds.
+### Current focus
 
-### Phase 2 — Stripe Gate (April 14–21)
-Goal: Paywalled audit feature. First dollar from web product.
-- Stripe Checkout — one-time $29 deep scan
-- Email delivery of audit report (no auth required yet)
-
-### Phase 3 — Distribution (April 21–28)
-Goal: First 100 users. First 3 paying customers.
-- r/ClaudeAI, r/cursor, r/LocalLLaMA, Show HN, X/Twitter, Substack
-
-### Phase 4 — Subscription + Auth (April 28–May 12)
-Goal: Recurring revenue. Multi-repo. PR integration.
-- GitHub OAuth
-- Multi-repo dashboard
-- GitHub PR creation: push generated CLAUDE.md directly to repo
+- Distribution: r/ClaudeAI, r/cursor, r/LocalLLaMA, Show HN, X/Twitter, Substack
+- One-time $29 deep web scan with audit report (Stripe Checkout + email delivery)
+- GitHub OAuth + multi-repo dashboard + PR creation (push generated CLAUDE.md directly to repo)
 
 ### Key Decisions
 
 | Decision | Rationale |
 |----------|-----------|
-| Web UI over CLI-only | CLI has low monetization ceiling; web enables Stripe gate |
-| One-time $29 before subscription | Lowest friction first purchase; validate willingness to pay |
-| Fly.io deployment | Consistent with existing infra |
+| Web UI alongside CLI | CLI alone has a low monetization ceiling; web enables Stripe gate + casual users |
+| Strict as a distinct tier (not a Pro add-on) | Procurement-driven buyers expect a CI-grade SKU with fail-closed + audit; Pro stays cheap for individuals |
+| One-time $29 before subscription on web | Lowest-friction first purchase; validates willingness to pay |
+| Fly.io for both server + web | Consistent infra, single ops surface |
+| Litestream over Fly volumes alone | SQLite + S3 replication gives point-in-time restore without leaving Fly |
 
 ### IP Notes
 - Core generation algorithm (repo structure → CLAUDE.md schema) is proprietary
 - Audit ruleset (anti-patterns, gap detection) is proprietary
-- Do not open-source the API or web layer; CLI can remain MIT
+- Source is Business Source License 1.1 (converts to MIT 4 years after each release per the BSL change date). Web/API layer remains closed pending the change date.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ ruff format src/ tests/
 
 ## License
 
-MIT
+Business Source License 1.1 — see [LICENSE](LICENSE). Each release converts to the MIT License four years after publication (per the BSL change date).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anchormd"
-version = "0.5.0"
+version = "0.6.0"
 description = "Generate and audit AI agent context files — tech debt scanner, GitHub health, cleanup agent"
 readme = "README.md"
 license = {text = "BSL-1.1"}
@@ -12,10 +12,10 @@ requires-python = ">=3.11"
 authors = [{name = "AreteDriver"}]
 keywords = ["ai", "coding-agent", "context-file", "tech-debt", "claude-code", "cursor", "windsurf"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/anchormd/__init__.py
+++ b/src/anchormd/__init__.py
@@ -1,6 +1,6 @@
 """AnchorMD — Generate and audit AI agent context files."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = [
     "__version__",

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from anchormd.cli import app
@@ -61,14 +62,12 @@ class TestCheckPresetAccess:
             check_preset_access("python-fastapi")
 
     def test_pro_preset_blocks_free_user(self) -> None:
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("react-native")
 
@@ -83,27 +82,23 @@ class TestCheckPresetAccess:
 
     def test_unknown_preset_gives_not_found(self) -> None:
         """Unknown presets should say 'not found', not upsell to Pro."""
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("totally-fake-preset")
 
     def test_unknown_preset_message_not_pro(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Unknown preset error should not mention Pro upgrade."""
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("nonexistent")
 


### PR DESCRIPTION
CLAUDE.md drifted from the codebase since v0.5.0:
- Bump documented version 0.5.0 -> 0.6.0; sync src/anchormd/__init__.py
  and pyproject.toml so the three sources of truth agree
- Update test count 134+~390 -> 811 (matches CHANGELOG.md)
- Add Strict tier ($49/seat/mo, $399/yr team-5, $1490/yr team-25) to
  Monetization with feature breakdown
- Refresh Architecture tree to include audit_logger, seats, telemetry,
  scanner, analyzers/, drift/, generators/, templates/, plus web frontend
  pages and license_server/litestream.yml
- Add 5 Strict endpoints to the API table (seats claim/release/list,
  audit log/export)
- Document ANCHORMD_STRICT, ANCHORMD_NO_AUDIT, ANCHORMD_TELEMETRY,
  ANCHORMD_DIR, ANMD_SMTP_HOST/PORT, ANMD_RATE_LIMIT env vars
- Replace stale "April 2026 Sprint" roadmap with shipped/current-focus
  retrospective
- Fix print()/logging anti-pattern wording so it doesn't read as
  forbidding rich.console / typer.echo

Metadata fixes:
- pyproject.toml classifier "License :: OSI Approved :: MIT License"
  -> "License :: Other/Proprietary License" (project ships under
  BSL-1.1; MIT only applies after the change date)
- Development Status 3-Alpha -> 4-Beta (live Stripe, paying customers,
  v0.6.0 with breaking changes)
- README.md "MIT" -> BSL-1.1 with link to LICENSE and explanation of
  the eventual MIT conversion