### PR TITLE
fix(types): clear 40 mypy errors, make mypy a hard CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,7 @@ jobs:
         run: ruff check src/ tests/
       - name: Format check
         run: ruff format --check src/ tests/
-      # Non-blocking for now: src/ has pre-existing type errors that the
-      # PR-scoped AI Quality Gate (changed files only) never surfaced.
-      # Ratchet to a hard gate (remove continue-on-error) once src/ is clean.
       - name: Type check
         run: mypy src/
-        continue-on-error: true
       - name: Test
         run: pytest tests/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "mypy==1.19.1",
     "ruff==0.15.11",
     "httpx>=0.27.0",
+    "types-PyYAML>=6.0.0",
     # License server runtime — needed so tests/license_server/ can be collected
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.27.0",
@@ -79,3 +80,9 @@ testpaths = ["tests"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
+
+# Optional LLM SDKs are imported lazily inside try/except ImportError and are
+# not installed in CI. Don't fail type-checking on their missing stubs.
+[[tool.mypy.overrides]]
+module = ["openai.*", "anthropic.*", "google.*"]
+ignore_missing_imports = true

--- a/src/anchormd/analyzers/commands.py
+++ b/src/anchormd/analyzers/commands.py
@@ -46,7 +46,8 @@ class CommandAnalyzer:
             return {}
         try:
             data = json.loads(pkg.read_text(errors="replace"))
-            return data.get("scripts", {})
+            scripts = data.get("scripts", {})
+            return scripts if isinstance(scripts, dict) else {}
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Cannot parse package.json: %s", e)
             return {}

--- a/src/anchormd/analyzers/github.py
+++ b/src/anchormd/analyzers/github.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 from datetime import UTC, datetime
+from typing import Any
 
 from anchormd.models import AnalysisResult, ForgeConfig, ProjectStructure
 
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 _GH_TIMEOUT = 10
 
 
-def _run_gh(args: list[str], cwd: str | None = None) -> dict | list | None:
+def _run_gh(args: list[str], cwd: str | None = None) -> dict[str, Any] | list[Any] | None:
     """Run a gh CLI command and return parsed JSON, or None on failure."""
     try:
         result = subprocess.run(
@@ -28,7 +29,8 @@ def _run_gh(args: list[str], cwd: str | None = None) -> dict | list | None:
         if result.returncode != 0:
             logger.debug("gh %s failed: %s", " ".join(args), result.stderr.strip())
             return None
-        return json.loads(result.stdout)
+        parsed: dict[str, Any] | list[Any] = json.loads(result.stdout)
+        return parsed
     except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as exc:
         logger.debug("gh command error: %s", exc)
         return None
@@ -108,7 +110,7 @@ class GitHubAnalyzer:
         findings["security"] = security
 
         # Branch protection
-        default_branch = findings["default_branch"]
+        default_branch = str(findings["default_branch"])
         protection = self._get_branch_protection(cwd, default_branch)
         findings["branch_protection"] = protection
 
@@ -133,7 +135,7 @@ class GitHubAnalyzer:
             section_content=section,
         )
 
-    def _get_issues(self, cwd: str) -> dict:
+    def _get_issues(self, cwd: str) -> dict[str, object]:
         """Get issue counts and staleness."""
         result: dict[str, object] = {"open": 0, "stale_30d": 0, "stale_90d": 0}
 
@@ -175,7 +177,7 @@ class GitHubAnalyzer:
         result["stale_90d"] = stale_90
         return result
 
-    def _get_pull_requests(self, cwd: str) -> dict:
+    def _get_pull_requests(self, cwd: str) -> dict[str, object]:
         """Get PR counts and staleness."""
         result: dict[str, object] = {"open": 0, "draft": 0, "stale_30d": 0}
 
@@ -213,31 +215,31 @@ class GitHubAnalyzer:
         result["stale_30d"] = stale
         return result
 
-    def _get_security(self, cwd: str) -> dict:
+    def _get_security(self, cwd: str) -> dict[str, int]:
         """Get security alert counts."""
         result: dict[str, int] = {"dependabot_alerts": 0, "code_scanning_alerts": 0}
 
-        # Dependabot alerts
-        alerts = _run_gh(
+        # Dependabot alerts (`--jq length` returns a bare count as text)
+        alerts = _run_gh_text(
             ["api", "repos/{owner}/{repo}/dependabot/alerts", "--jq", "length"],
             cwd=cwd,
         )
-        if alerts is not None:
+        if alerts:
             with contextlib.suppress(ValueError, TypeError):
                 result["dependabot_alerts"] = int(alerts)
 
         # Code scanning
-        scanning = _run_gh(
+        scanning = _run_gh_text(
             ["api", "repos/{owner}/{repo}/code-scanning/alerts", "--jq", "length"],
             cwd=cwd,
         )
-        if scanning is not None:
+        if scanning:
             with contextlib.suppress(ValueError, TypeError):
                 result["code_scanning_alerts"] = int(scanning)
 
         return result
 
-    def _get_branch_protection(self, cwd: str, branch: str) -> dict:
+    def _get_branch_protection(self, cwd: str, branch: str) -> dict[str, object]:
         """Check if the default branch has protection rules."""
         result: dict[str, object] = {"enabled": False}
 
@@ -255,7 +257,7 @@ class GitHubAnalyzer:
 
         return result
 
-    def _get_releases(self, cwd: str) -> dict:
+    def _get_releases(self, cwd: str) -> dict[str, object]:
         """Get recent release info."""
         result: dict[str, object] = {"total": 0, "latest": None, "latest_date": None}
 
@@ -274,7 +276,7 @@ class GitHubAnalyzer:
 
         return result
 
-    def _get_workflows(self, cwd: str) -> dict:
+    def _get_workflows(self, cwd: str) -> dict[str, object]:
         """Get CI workflow status."""
         result: dict[str, object] = {"count": 0, "failing": []}
 
@@ -296,7 +298,7 @@ class GitHubAnalyzer:
         result["failing"] = [name for name, conclusion in seen.items() if conclusion == "failure"]
         return result
 
-    def _calculate_health(self, findings: dict) -> int:
+    def _calculate_health(self, findings: dict[str, Any]) -> int:
         """Calculate 0-100 GitHub health score."""
         score = 100
 
@@ -328,9 +330,9 @@ class GitHubAnalyzer:
         if not findings.get("license"):
             score -= 5
 
-        return max(0, min(100, score))
+        return int(max(0, min(100, score)))
 
-    def _render_section(self, findings: dict) -> str:
+    def _render_section(self, findings: dict[str, Any]) -> str:
         """Render GitHub health section for context file."""
         if not findings.get("available"):
             return ""

--- a/src/anchormd/analyzers/harvest.py
+++ b/src/anchormd/analyzers/harvest.py
@@ -12,6 +12,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from anchormd.analyzers.suggestions import Suggestion, suggest_for
 
@@ -143,7 +144,7 @@ def harvest(
         return report
 
     # signature -> (tool, count, set(session_ids), examples)
-    agg: dict[str, dict] = defaultdict(
+    agg: dict[str, dict[str, Any]] = defaultdict(
         lambda: {"tool": "?", "count": 0, "sessions": set(), "examples": []}
     )
 

--- a/src/anchormd/analyzers/language.py
+++ b/src/anchormd/analyzers/language.py
@@ -221,7 +221,7 @@ class LanguageAnalyzer:
         primary = findings.get("primary_language")
         langs = findings.get("languages", {})
         if primary:
-            other_langs = [k for k in langs if k != primary]  # type: ignore[union-attr]
+            other_langs = [k for k in langs if k != primary] if isinstance(langs, dict) else []
             lang_str = str(primary)
             if other_langs:
                 lang_str += f", {', '.join(other_langs)}"

--- a/src/anchormd/cleanup.py
+++ b/src/anchormd/cleanup.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class CleanupPlan:
         return sum(1 for a in self.actions if a.error)
 
 
-def _run_gh(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess:
+def _run_gh(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
     """Run a gh CLI command."""
     return subprocess.run(
         ["gh", *args],
@@ -55,13 +56,14 @@ def _run_gh(args: list[str], cwd: str | None = None) -> subprocess.CompletedProc
     )
 
 
-def _run_gh_json(args: list[str], cwd: str | None = None) -> list | dict | None:
+def _run_gh_json(args: list[str], cwd: str | None = None) -> list[Any] | dict[str, Any] | None:
     """Run gh and parse JSON output."""
     try:
         result = _run_gh(args, cwd=cwd)
         if result.returncode != 0:
             return None
-        return json.loads(result.stdout)
+        parsed: list[Any] | dict[str, Any] = json.loads(result.stdout)
+        return parsed
     except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
         return None
 

--- a/src/anchormd/drift/adapters/anthropic.py
+++ b/src/anchormd/drift/adapters/anthropic.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from anchormd.drift.adapters.base import ModelAdapter
 from anchormd.exceptions import DriftError
@@ -25,7 +26,7 @@ class AnthropicAdapter(ModelAdapter):
             raise DriftError("ANTHROPIC_API_KEY environment variable not set.")
 
         client = anthropic.Anthropic(api_key=api_key)
-        kwargs: dict = {
+        kwargs: dict[str, Any] = {
             "model": self._model,
             "max_tokens": 4096,
             "messages": [{"role": "user", "content": prompt}],
@@ -34,7 +35,7 @@ class AnthropicAdapter(ModelAdapter):
             kwargs["system"] = system
 
         response = client.messages.create(**kwargs)
-        return response.content[0].text  # type: ignore[union-attr]
+        return str(response.content[0].text)
 
     def name(self) -> str:
         return self._model

--- a/src/anchormd/drift/adapters/google.py
+++ b/src/anchormd/drift/adapters/google.py
@@ -32,7 +32,7 @@ class GoogleAdapter(ModelAdapter):
             system_instruction=system,
         )
         response = gen_model.generate_content(prompt)
-        return response.text
+        return str(response.text)
 
     def name(self) -> str:
         return self._model

--- a/src/anchormd/drift/adapters/ollama.py
+++ b/src/anchormd/drift/adapters/ollama.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Any
 
 from anchormd.drift.adapters.base import ModelAdapter
 from anchormd.exceptions import DriftError
@@ -22,7 +23,7 @@ class OllamaAdapter(ModelAdapter):
         except ImportError as exc:
             raise DriftError("httpx not installed. Run: pip install httpx") from exc
 
-        payload: dict = {
+        payload: dict[str, Any] = {
             "model": self._model,
             "prompt": prompt,
             "stream": False,
@@ -45,7 +46,7 @@ class OllamaAdapter(ModelAdapter):
         except json.JSONDecodeError as exc:
             raise DriftError(f"Ollama returned invalid JSON: {resp.text[:200]}") from exc
 
-        return data.get("response", "")
+        return str(data.get("response", ""))
 
     def name(self) -> str:
         return f"ollama/{self._model}"

--- a/src/anchormd/drift/adapters/openai.py
+++ b/src/anchormd/drift/adapters/openai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from anchormd.drift.adapters.base import ModelAdapter
 from anchormd.exceptions import DriftError
@@ -25,7 +26,7 @@ class OpenAIAdapter(ModelAdapter):
             raise DriftError("OPENAI_API_KEY environment variable not set.")
 
         client = openai.OpenAI(api_key=api_key)
-        messages: list[dict] = []
+        messages: list[dict[str, Any]] = []
         if system:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})

--- a/src/anchormd/drift/fixer.py
+++ b/src/anchormd/drift/fixer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -64,7 +65,7 @@ def suggest_fixes(
     and uses an LLM to suggest CLAUDE.md additions.
     """
     # Collect failing benchmarks.
-    failures: list[dict] = []
+    failures: list[dict[str, Any]] = []
     for result in run.results:
         failing_checks = [c for c in result.checks if not c.passed]
         if failing_checks:

--- a/src/anchormd/drift/storage.py
+++ b/src/anchormd/drift/storage.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
@@ -112,7 +113,7 @@ def load_history(root: Path) -> list[RunRecord]:
     return records
 
 
-def load_trend(root: Path) -> list[dict]:
+def load_trend(root: Path) -> list[dict[str, Any]]:
     """Load cached trend data, or return empty list."""
     path = root / _TREND_FILE
     if not path.is_file():
@@ -124,7 +125,7 @@ def load_trend(root: Path) -> list[dict]:
         return []
 
 
-def save_trend(root: Path, trend_data: list[dict]) -> None:
+def save_trend(root: Path, trend_data: list[dict[str, Any]]) -> None:
     """Persist aggregated trend data."""
     ensure_dirs(root)
     path = root / _TREND_FILE

--- a/src/anchormd/drift/trend.py
+++ b/src/anchormd/drift/trend.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from anchormd.drift.models import RunRecord
 
 
-def aggregate_trend(history: list[RunRecord]) -> list[dict]:
+def aggregate_trend(history: list[RunRecord]) -> list[dict[str, Any]]:
     """Aggregate run history into trend data points."""
     return [
         {

--- a/src/anchormd/telemetry.py
+++ b/src/anchormd/telemetry.py
@@ -96,7 +96,7 @@ class TelemetryStore:
 
     def get_total_events(self) -> int:
         row = self._conn.execute("SELECT COUNT(*) as cnt FROM events").fetchone()
-        return row["cnt"]
+        return int(row["cnt"])
 
     def get_first_event_time(self) -> str | None:
         row = self._conn.execute("SELECT MIN(timestamp) as ts FROM events").fetchone()

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from anchormd.cli import app
@@ -71,14 +72,12 @@ class TestCheckPresetAccess:
             check_preset_access("python-fastapi")
 
     def test_pro_preset_blocks_free_user(self) -> None:
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("react-native")
 
@@ -93,27 +92,23 @@ class TestCheckPresetAccess:
 
     def test_unknown_preset_gives_not_found(self) -> None:
         """Unknown presets should say 'not found', not upsell to Pro."""
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("totally-fake-preset")
 
     def test_unknown_preset_message_not_pro(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Unknown preset error should not mention Pro upgrade."""
-        from click.exceptions import Exit
-
         with (
             patch(
                 "anchormd.licensing._find_license_key",
                 return_value=None,
             ),
-            pytest.raises(Exit),
+            pytest.raises(typer.Exit),
         ):
             check_preset_access("nonexistent")
 


### PR DESCRIPTION
Follow-up to the CI hardening in #17. The new `mypy src/` step was added as **non-blocking** because `src/` had 40 pre-existing type errors that the PR-scoped AI Quality Gate (changed files only) never surfaced. This clears all 40 and flips the gate to blocking.

## Changes
- **Generics**: annotate bare `dict`/`list`/`CompletedProcess` across `analyzers/`, `cleanup.py`, `drift/`, `telemetry.py`.
- **`github.py`**: `_get_security` now uses the text helper for `--jq length` calls (was `int()` of a `dict|list` union); `str()`/`int()` coercions where `findings: dict[str, Any]` propagated `Any`.
- **`language.py`**: guard the non-iterable `findings.get("languages")` access instead of a mismatched `# type: ignore`.
- **Adapters**: coerce `Any` SDK responses to `str` (ollama/anthropic/google).
- **`pyproject.toml`**: `ignore_missing_imports` for the optional, lazily-imported LLM SDKs (`openai`/`anthropic`/`google`); add `types-PyYAML` for `drift/storage.py`.
- **`ci.yml`**: drop `continue-on-error` — `mypy src/` is clean.

## Verification
- `mypy src/` → Success, 56 files, 0 errors.
- `pytest tests/` → **771 passed**.
- No behavior change beyond the `_run_gh_text` switch (same runtime result) and defensive `str()`/`int()` coercions.

Base is `codex/security-hardening` so the gate-flip lands together with the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)