### PR TITLE
deps: bump mypy to 2.1.0 (coordinated) + sync ruff workflow pin

### DIFF
--- a/.github/workflows/ai-quality-gate.yml
+++ b/.github/workflows/ai-quality-gate.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUFF_VERSION: "0.15.11"
-  MYPY_VERSION: "1.19.1"
+  RUFF_VERSION: "0.15.15"
+  MYPY_VERSION: "2.1.0"
   PYTEST_VERSION: "9.0.3"
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ drift = [
 ]
 dev = [
     "pytest==9.0.3",
-    "mypy==1.19.1",
+    "mypy==2.1.0",
     "ruff==0.15.15",
     "httpx>=0.27.0",
     "types-PyYAML>=6.0.0",


### PR DESCRIPTION
Supersedes Dependabot **#31**, which only touched `pyproject.toml` and would have left `ai-quality-gate.yml` installing the old mypy.

- `mypy` 1.19.1 → **2.1.0** in **both** `pyproject.toml` and the workflow's `MYPY_VERSION`
- also synced `RUFF_VERSION` 0.15.11 → 0.15.15 (drifted after #29 bumped ruff in pyproject only)

Verified locally: `mypy 2.1.0` is clean on `src/` (58 files, 0 new errors) — the hard gate still passes.

Closes #31