### PR TITLE
deps(web): bump react-markdown 9 -> 10

### DIFF
--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@vercel/speed-insights": "^2.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^9.0.1"
+        "react-markdown": "^10.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -13,7 +13,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^9.0.1"
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
Supersedes Dependabot **#24**.

The app renders markdown via bare `<ReactMarkdown>{content}</ReactMarkdown>` in `App.jsx` + `ReposPage.jsx` — no `className` prop or custom renderers, which are the surfaces that changed in v10. So this is low-risk.

Verified locally: `npm run build` succeeds, 0 vulnerabilities.

Closes #24